### PR TITLE
Make atuin work in codespaces

### DIFF
--- a/stow/zsh-codespace/.zshrc.d/00_codespace.zsh
+++ b/stow/zsh-codespace/.zshrc.d/00_codespace.zsh
@@ -7,3 +7,7 @@ plugins=(
     git
     vi-mode
 )
+
+if [ -d "$HOME/.atuin/bin" ]; then
+    export PATH="$PATH:$HOME/.atuin/bin"
+fi  


### PR DESCRIPTION
The atuin install script either changed its install script or this never worked in codespaces. I'm not sure which but this change just adds the $HOME/.atuin/bin to the PATH in the zshrc.d/00_codespace.zsh file which should make this work in code spaces.