### PR TITLE
refactor(setup): simplify recipe override selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Codespaces will now automagically clone this repository and run the `./setup` sc
 
 ### ./setup
 
-`./setup` is the entrypoint for interacting with this repository. It is a shell script that requires no arguments and runs through all setup tasks for a platform. It should always be safe to rerun `./steup` becuase it should be an idempotent script.
+`./setup` is the entrypoint for interacting with this repository. It is a shell script that can be run without arguments to auto-detect the current platform and run through all setup tasks for the matching recipe, or with an optional first argument to select a recipe explicitly. It should always be safe to rerun `./setup` because it should be an idempotent script.
 
 Its primary job is to choose a *recipe* and then run the appropriate setup steps based on that recipe. By default, `./setup` auto-detects the current platform and chooses the matching recipe. A recipe can also be selected explicitly by passing it as the first argument, or by setting `TARGET_RECIPE_NAME`.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,17 @@ Codespaces will now automagically clone this repository and run the `./setup` sc
 
 `./setup` is the entrypoint for interacting with this repository. It is a shell script that requires no arguments and runs through all setup tasks for a platform. It should always be safe to rerun `./steup` becuase it should be an idempotent script.
 
-It's primary job is to choose a *recipe* either by taking a recipe passed in via an environment variable or by choosing an appropriate one based on the detected platform. It then runs through and executes the appropriate set of steps based on the settings in the recipe. Each step is typically encapsulated by a script in the `scripts/` directory.
+Its primary job is to choose a *recipe* and then run the appropriate setup steps based on that recipe. By default, `./setup` auto-detects the current platform and chooses the matching recipe. A recipe can also be selected explicitly by passing it as the first argument, or by setting `TARGET_RECIPE_NAME`.
+
+Examples:
+
+```sh
+./setup
+./setup macosx
+TARGET_RECIPE_NAME=codespaces ./setup
+```
+
+Each setup step is typically encapsulated by a script in the `scripts/` directory.
 
 ### recipes/
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -67,14 +67,17 @@ Status:
 
 The Atuin setup branch now evaluates `SETUP_ATUIN` as a command-style boolean, so `SETUP_ATUIN=false` skips the installer and `SETUP_ATUIN=true` runs it.
 
-### 4. Medium: recipe-level control for auto-selection is dead code or misnamed
+### 4. Fixed: recipe-level control for auto-selection was dead code or misnamed
 
 References:
 
-- [`setup:8`](./setup)
-- [`recipes/default:9`](./recipes/default)
+- [`setup:7`](./setup)
 
-`setup` reads `SETUP_AUTOCHOOSE_RECIPE`, but recipes define `AUTOCHOOSE_PLATFORM_RECIPE`. As written, the recipe cannot influence that behavior. This is a maintainability bug and a sign the contract between `setup` and recipes has drifted.
+Status:
+
+- fixed in the working tree
+
+The dead recipe-level `AUTOCHOOSE_PLATFORM_RECIPE` setting has been removed, and `setup` no longer uses a separate `SETUP_AUTOCHOOSE_RECIPE` flag. Recipe selection now follows a simpler contract: an explicit recipe argument wins, `TARGET_RECIPE_NAME` can provide an environment override, and `./setup` with neither falls back to platform auto-detection.
 
 ### 5. Medium: the bootstrap does not fail fast
 

--- a/setup
+++ b/setup
@@ -12,6 +12,11 @@ source scripts/common.sh
 ## Main ##
 # Load recipe
 if [ -n "$TARGET_RECIPE_NAME" ]; then
+    if [[ ! "$TARGET_RECIPE_NAME" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        echo_error "Invalid recipe name: '$TARGET_RECIPE_NAME'"
+        exit 1
+    fi
+
     echo_info "Using specified target recipe: '$TARGET_RECIPE_NAME'"
     recipe_to_source="$TARGET_RECIPE_NAME"
 else

--- a/setup
+++ b/setup
@@ -4,14 +4,17 @@ set -u
 
 ## Globals ##
 RECIPE_DIR="${RECIPE_DIR:-./recipes}"
-SETUP_AUTOCHOOSE_RECIPE="${SETUP_AUTOCHOOSE_RECIPE:-true}"
+TARGET_RECIPE_NAME="${1:-${TARGET_RECIPE_NAME:-}}"
 
 ## functions ##
 source scripts/common.sh
 
 ## Main ##
 # Load recipe
-if "${SETUP_AUTOCHOOSE_RECIPE}"; then
+if [ -n "$TARGET_RECIPE_NAME" ]; then
+    echo_info "Using specified target recipe: '$TARGET_RECIPE_NAME'"
+    recipe_to_source="$TARGET_RECIPE_NAME"
+else
     # Platform
     KERNEL_NAME="$(uname -s)"
     CODESPACES="${CODESPACES:-false}"
@@ -35,21 +38,12 @@ if "${SETUP_AUTOCHOOSE_RECIPE}"; then
 
     echo_info "Using automatically chosen recipe: '$platform_recipe'"
     recipe_to_source="$platform_recipe"
-else
-    if [ -z "${TARGET_RECIPE_NAME:-}" ]; then
-        echo_error "No target recipe specified and auto-choose is disabled. Exiting."
-        exit 1
-    fi
-
-    echo_info "Using specified target recipe: '$TARGET_RECIPE_NAME'"
-    recipe_to_source="$TARGET_RECIPE_NAME"
 fi
 
 if ! source_recipe "$recipe_to_source"; then
     echo_error "Failed to source recipe '$recipe_to_source'"
     exit 1
 fi
-
 
 # sudo
 if "${SUDO_UP_FRONT}"; then


### PR DESCRIPTION
Use an explicit recipe argument or TARGET_RECIPE_NAME as the override path, and fall back to platform auto-detection when neither is provided.

This removes the separate SETUP_AUTOCHOOSE_RECIPE flag and the dead recipe-level auto-selection setting.